### PR TITLE
added Designing for Scalability with Erlang/OTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ Elixir, based on Erlang’s virtual machine and ecosystem, makes it easier to ac
 
 Write code that writes code with Elixir macros. Macros make metaprogramming possible and define the language itself. In this book, you’ll learn how to use macros to extend the language with fast, maintainable code and share functionality in ways you never thought possible. You’ll discover how to extend Elixir with your own first-class features, optimize performance, and create domain-specific languages.
 
+###[Designing for Scalability with Erlang/OTP](http://shop.oreilly.com/product/0636920024149.do)
+
+<img src="http://akamaicovers.oreilly.com/images/0636920024149/lrg.jpg" width="120px"/>
+
+If you need to build a scalable, fault tolerant system with requirements for high availability, discover why the Erlang/OTP platform stands out for the breadth, depth, and consistency of its features. This hands-on guide demonstrates how to use the Erlang programming language and its OTP framework of reusable libraries, tools, and design principles to develop complex commercial-grade systems that simply cannot fail.
+
 **Web Development**
 ---
 


### PR DESCRIPTION
This PR adds _Designing for Scalability with Erlang/OTP_ to the Advanced Books section.  All content in this book is applicable to Elixir developers who want to create extremely available services.

I'm not sure what the diff of the last line in the file is all about -- I tried in MacVim, then /bin/ed (really), then on the GitHub website directly, and in all cases the last-line diff appears without me having touched it at all.
