### PR TITLE
Hands-on Elixir & OTP added to the list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: ruby
-rvm: 2.2
+rvm: 2.4
 before_script: gem install awesome_bot
 script: awesome_bot README.md --allow-dupe --allow-redirect --allow-ssl

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ A multi-user game, web site, cloud application, or networked database can have t
 
 Property-based testing helps you create better, more solid tests with little code. By using the PropEr framework in both Erlang and Elixir, this book teaches you how to automatically generate test cases, test stateful programs, and change how you design your software for more principled and reliable approaches. You will be able to better explore the problem space, validate the assumptions you make when coming up with program behavior, and expose unexpected weaknesses in your design. PropEr will even show you how to reproduce the bugs it found. With this book, you will be writing efficient property-based tests in no time.
 
-###[Hands-on Elixir & OTP: Cryptocurrency trading bot](https://www.elixircryptobot.com) *Free*
+### [Hands-on Elixir & OTP: Cryptocurrency trading bot](https://www.elixircryptobot.com) *Free*
 
 <img src="https://github.com/frathon/hands-on-elixir-and-otp-cryptocurrency-trading-bot/raw/main/images/cover.png" width="120px"/>
 

--- a/README.md
+++ b/README.md
@@ -174,6 +174,12 @@ A multi-user game, web site, cloud application, or networked database can have t
 
 Property-based testing helps you create better, more solid tests with little code. By using the PropEr framework in both Erlang and Elixir, this book teaches you how to automatically generate test cases, test stateful programs, and change how you design your software for more principled and reliable approaches. You will be able to better explore the problem space, validate the assumptions you make when coming up with program behavior, and expose unexpected weaknesses in your design. PropEr will even show you how to reproduce the bugs it found. With this book, you will be writing efficient property-based tests in no time.
 
+###[Hands-on Elixir & OTP: Cryptocurrency trading bot](https://www.elixircryptobot.com) *Free*
+
+<img src="https://github.com/frathon/hands-on-elixir-and-otp-cryptocurrency-trading-bot/raw/main/images/cover.png" width="120px"/>
+
+Want to learn Elixir & OTP by creating a real-world project? With Hands-on Elixir & OTP: Cryptocurrency trading bot you will gain hands-on experience by working on an interesting software project. We will explore all the key abstractions and essential principles through iterative implementation improvements.
+
 **Web Development**
 ---
 
@@ -242,6 +248,7 @@ Give users the real-time experience they expect, by using Elixir and Phoenix Cha
 * [Discover Elixir & Phoenix](https://www.ludu.co/course/discover-elixir-phoenix)
 * [Elixir School](http://elixirschool.com/)
 * [Elixir for Programmers](https://codestool.coding-gnome.com/courses/elixir-for-programmers)
+* [Frathon's YouTube Channel](https://youtube.com/c/frathon)
 
 Contributing
 ====


### PR DESCRIPTION
Hello :wave: 

I added my book and YouTube channel to the list.

To be able to run Travis-CI tests I needed to update the Ruby version to 2.4 but the following non-related issues are still present:

```
Issues :-(

> Links 

  1. [L046]  https://startlearningelixir.com/r/etudes-for-elixir Failed to open TCP connection to startlearningelixir.com:443 (Connection refused - connect(2) for "startlearningelixir.com" port 443) 

  2. [L088]  https://startlearningelixir.com/r/take-off-with-elixir Failed to open TCP connection to startlearningelixir.com:443 (Connection refused - connect(2) for "startlearningelixir.com" port 443) 

  3. [L090]  https://startlearningelixir.com/images/resources/take-off-with-elixir-4c474927f8e6533e07bf2a8f18194d54.jpg?vsn=d Failed to open TCP connection to startlearningelixir.com:443 (Connection refused - connect(2) for "startlearningelixir.com" port 443) 

  4. [L165] 404 https://pragprog.com/book/jaerlang2/programming-erlang  

  5. [L224] 404 https://pragprog.com/book/phoenix/programming-phoenix
```

Would it be possible to merge my PR without fixing those as they are not related?